### PR TITLE
fix bug when startpoint not in center

### DIFF
--- a/Source/BubbleTransition.swift
+++ b/Source/BubbleTransition.swift
@@ -55,7 +55,10 @@ public class BubbleTransition: NSObject, UIViewControllerAnimatedTransitioning {
             let presentedControllerView = transitionContext.viewForKey(UITransitionContextToViewKey)!
 
             let originalCenter = presentedControllerView.center
-            let offset = sqrt(startingPoint.x * startingPoint.x + startingPoint.y * startingPoint.y) * 2
+            let originalSize = presentedControllerView.frame.size
+            let lengthX = fmax(startingPoint.x, originalSize.width - startingPoint.x);
+            let lengthY = fmax(startingPoint.y, originalSize.height - startingPoint.y)
+            let offset = sqrt(lengthX * lengthX + lengthY * lengthY) * 2;
             let size = CGSize(width: offset, height: offset)
             bubble = UIView(frame: CGRect(origin: CGPointZero, size: size))
             bubble!.layer.cornerRadius = size.height / 2


### PR DESCRIPTION
When startpoint.x or startpoint.y small than controllerView's width or height, it will have a error.

before:

![before](https://cloud.githubusercontent.com/assets/1998065/7669400/29f8b528-fca4-11e4-9651-f0f5b2e99b09.gif)

after:
![after](https://cloud.githubusercontent.com/assets/1998065/7669401/2cf9764a-fca4-11e4-8d04-da034b437982.gif)
