### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img width="420" height="240" src="assets/logo.png"/>
 </p>
 
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/BubbleTransition/badge.svg)](http://cocoapods.org/?q=bubbletransition)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/BubbleTransition/badge.svg)](http://cocoapods.org/?q=bubbletransition)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 ![Swift 2.0](https://img.shields.io/badge/swift-2.0-orange.svg)
 
@@ -18,7 +18,7 @@ A custom modal transition that presents and dismiss a controller inside an expan
 ![BubbleTransition](https://raw.githubusercontent.com/andreamazz/BubbleTransition/master/assets/screenshot.gif)
 
 # Usage
-Install through [Cocoapods](http://cocoapods.org):
+Install through [CocoaPods](http://cocoapods.org):
 ```
 pod 'BubbleTransition', '~> 1.0.0'
 

--- a/README.md
+++ b/README.md
@@ -1,123 +1,82 @@
-<p align="center">
-  <img width="420" height="240" src="assets/logo.png"/>
-</p>
+# BubbleTransition
 
-[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/BubbleTransition/badge.svg)](http://cocoapods.org/?q=bubbletransition)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-![Swift 2.0](https://img.shields.io/badge/swift-2.0-orange.svg)
+[![CI Status](http://img.shields.io/travis/王易平/BubbleTransition.svg?style=flat)](https://travis-ci.org/王易平/BubbleTransition)
+[![Version](https://img.shields.io/cocoapods/v/BubbleTransition.svg?style=flat)](http://cocoapods.org/pods/BubbleTransition)
+[![License](https://img.shields.io/cocoapods/l/BubbleTransition.svg?style=flat)](http://cocoapods.org/pods/BubbleTransition)
+[![Platform](https://img.shields.io/cocoapods/p/BubbleTransition.svg?style=flat)](http://cocoapods.org/pods/BubbleTransition)
 
-A custom modal transition that presents and dismiss a controller inside an expanding and shrinking _bubble_.
-
-<p align="center">
-  <a href='https://appetize.io/app/tck0418dftyfjxkqrfu34rwt44' alt='Live demo'>
-    <img width="50" height="60" src="assets/demo.png"/>
-  </a>
-</p>
+An objective-C version of [andreamazz/BubbleTransition](https://github.com/andreamazz/BubbleTransition). A custom modal transition that presents and dismiss a controller inside an expanding and shrinking _bubble_.
 
 # Screenshot
-![BubbleTransition](https://raw.githubusercontent.com/andreamazz/BubbleTransition/master/assets/screenshot.gif)
+![BubbleTransition](https://raw.githubusercontent.com/epingwang/BubbleTransision/master/Pod/Assets/screenshot.gif)
 
-# Usage
-Install through [CocoaPods](http://cocoapods.org):
-```
-pod 'BubbleTransition', '~> 1.0.0'
+## Usage
 
-use_frameworks!
-```
-Install through [Carthage](https://github.com/Carthage/Carthage):
-```
-github "andreamazz/BubbleTransition"
+Install through [CocoaPods](http://cocoapods.org)
+```ruby
+pod 'BubbleTransition-objc', '~> 0.1'
 ```
 
-## Swift 1.2
-Version `1.0.0` targets Swift 2, if you are building with version `1.2` checkout the `swift-1.2` branch.
-```
-pod 'BubbleTransition', git: 'https://github.com/andreamazz/BubbleTransition', branch: 'swift-1.2'
+## Installation
 
-use_frameworks!
-```
-
-#Setup
 Have your viewcontroller conform to `UIViewControllerTransitioningDelegate`. Set the `transitionMode`, the `startingPoint`, the `bubbleColor` and the `duration`.
-```swift
-let transition = BubbleTransition()
+```objc
 
-override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-    let controller = segue.destinationViewController
-    controller.transitioningDelegate = self
-    controller.modalPresentationStyle = .Custom
+-(void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
+{
+    UIViewController *controller = segue.destinationViewController;
+    controller.transitioningDelegate = self;
+    controller.modalPresentationStyle = UIModalPresentationCustom;
 }
 
-// MARK: UIViewControllerTransitioningDelegate
+#pragma mark - UIViewControllerTransitioningDelegate
 
-func animationControllerForPresentedController(presented: UIViewController, presentingController presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-    transition.transitionMode = .Present
-    transition.startingPoint = someButton.center
-    transition.bubbleColor = someButton.backgroundColor!
-    return transition
+-(id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented presentingController:(UIViewController *)presenting sourceController:(UIViewController *)source
+{
+    self.transition.transitionMode = YPBubbleTransitionModePresent;
+    self.transition.startPoint = someButton.center;
+    self.transition.bubbleColor = someButton.backgroundColor;
+    return self.transition;
 }
 
-func animationControllerForDismissedController(dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-    transition.transitionMode = .Dismiss
-    transition.startingPoint = someButton.center
-    transition.bubbleColor = someButton.backgroundColor!
-    return transition
+-(id<UIViewControllerAnimatedTransitioning>)animationControllerForDismissedController:(UIViewController *)dismissed
+{
+    self.transition.transitionMode = YPBubbleTransitionModeDismiss;
+    self.transition.startPoint = someButton.center;
+    self.transition.bubbleColor = someButton.backgroundColor;
+    return self.transition;
 }
+
+
 ```
-
-You can find the Objective-C equivalent [here](https://gist.github.com/andreamazz/9b0d6c7db065555ec0d7).
 
 #Properties
-```swift
-var startingPoint = CGPointZero
+```objc
+CGPoint startPoint = CGPointZero;
 ```
 The point that originates the bubble.
 
-```swift
-var duration = 0.5
+```objc
+CGFloat duration = 0.5;
 ```
 The transition duration.
 
-```swift
-var transitionMode: BubbleTranisionMode = .Present
+```objc
+YPBubbleTransitionMode transitionMode = YPBubbleTransitionModePresent;
 ```
-The transition direction. Either `.Present`, `.Dismiss` or `.Pop`.
+The transition direction. Either `YPBubbleTransitionModePresent` or `YPBubbleTransitionModeDismiss`.
 
 ```swift
-var bubbleColor: UIColor = .whiteColor()
+UIColor *bubbleColor = [UIColor whiteColor];
 ```
 The color of the bubble. Make sure that it matches the destination controller's background color.  
 
 Checkout the sample project for the full implementation.
 
-#Author
-[Andrea Mazzini](https://twitter.com/theandreamazz). I'm available for freelance work, feel free to contact me. 
+## Author
 
-Want to support the development of [these free libraries](https://cocoapods.org/owners/734)? Buy me a coffee ☕️ via [Paypal](https://www.paypal.me/andreamazzini).  
+epingwang
 
-#Contributors
-Thanks to [everyone](https://github.com/andreamazz/BubbleTransition/graphs/contributors) kind enough to submit a pull request. 
+## License
 
-#MIT License
-
-	Copyright (c) 2015 Andrea Mazzini. All rights reserved.
-
-	Permission is hereby granted, free of charge, to any person obtaining a
-	copy of this software and associated documentation files (the "Software"),
-	to deal in the Software without restriction, including
-	without limitation the rights to use, copy, modify, merge, publish,
-	distribute, sublicense, and/or sell copies of the Software, and to
-	permit persons to whom the Software is furnished to do so, subject to
-	the following conditions:
-
-	The above copyright notice and this permission notice shall be included
-	in all copies or substantial portions of the Software.
-
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-	OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-	MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-	CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-	TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-	SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-	
+BubbleTransition is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
