### PR TITLE
When build toVC using getter and setter code only like :

### DIFF
--- a/Source/BubbleTransition.swift
+++ b/Source/BubbleTransition.swift
@@ -145,6 +145,7 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
                     containerView.insertSubview(self.bubble, belowSubview: returningControllerView)
                 }
                 }) { (_) in
+                    returningControllerView.center = originalCenter;
                     returningControllerView.removeFromSuperview()
                     self.bubble.removeFromSuperview()
                     transitionContext.completeTransition(true)


### PR DESCRIPTION
# 

//BTModalViewController is the toVC
- (ModalViewController *)BTModalViewController {
  if (!_BTModalViewController) {
      _BTModalViewController = [[ModalViewController alloc] init];
      _BTModalViewController.transitioningDelegate = self;
      _BTModalViewController.modalPresentationStyle = UIModalPresentationCustom;
  }
  return _BTModalViewController;
  }
  =======

The toVC is still in the memory, so we need to reset
 returningControllerView.center = originalCenter;

PS:
I have made the Objective-C code for BubbleTransition at:
https://github.com/rushairer/BubbleTransitionForObjC
