### PR TITLE
Added `beginAppearanceTransition` and `endAppearanceTransition` to transition

### DIFF
--- a/Source/BubbleTransition.swift
+++ b/Source/BubbleTransition.swift
@@ -97,6 +97,12 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
         
         let containerView = transitionContext.containerView
         
+        let fromViewController = transitionContext.viewController(forKey: .from)
+        let toViewController = transitionContext.viewController(forKey: .to)
+
+        fromViewController?.beginAppearanceTransition(false, animated: true)
+        toViewController?.beginAppearanceTransition(true, animated: true)
+
         if transitionMode == .present {
             let presentedControllerView = transitionContext.view(forKey: UITransitionContextViewKey.to)!
             let originalCenter = presentedControllerView.center
@@ -122,7 +128,10 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
                 presentedControllerView.center = originalCenter
                 }, completion: { (_) in
                     transitionContext.completeTransition(true)
-            }) 
+                    
+                    fromViewController?.endAppearanceTransition()
+                    toViewController?.endAppearanceTransition()
+            })
         } else {
             let key = (transitionMode == .pop) ? UITransitionContextViewKey.to : UITransitionContextViewKey.from
             let returningControllerView = transitionContext.view(forKey: key)!
@@ -148,7 +157,10 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
                     returningControllerView.removeFromSuperview()
                     self.bubble.removeFromSuperview()
                     transitionContext.completeTransition(true)
-            }) 
+                    
+                    fromViewController?.endAppearanceTransition()
+                    toViewController?.endAppearanceTransition()
+            })
         }
     }
 }


### PR DESCRIPTION
Added `beginAppearanceTransition` and `endAppearanceTransition` to both the `fromViewController` and `toViewController` to ensure that both would properly call their `viewWillAppear`, `viewDidAppear`, `viewWillDisappear`, `viewDidDisappear` methods when transitioning from one to the other