### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Improved documentation. Minor refactoring.
 
 ## [1.0.0](https://github.com/andreamazz/BubbleTransition/releases/tag/1.0.0)
 
-###Added
+### Added
 - Support to Swift 2.0 syntax. checkout version 0.2 and previous for Swift 1.2.  
 
 ## [0.2](https://github.com/andreamazz/BubbleTransition/releases/tag/0.2)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
