### PR TITLE
Fixed: bubble is displayed in other custom transition animation.

### DIFF
--- a/Source/BubbleTransition.swift
+++ b/Source/BubbleTransition.swift
@@ -128,7 +128,7 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
                 presentedControllerView.center = originalCenter
                 }, completion: { (_) in
                     transitionContext.completeTransition(true)
-                    
+                    self.bubble.isHidden = true
                     fromViewController?.endAppearanceTransition()
                     toViewController?.endAppearanceTransition()
             })
@@ -141,6 +141,7 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
             bubble.frame = frameForBubble(originalCenter, size: originalSize, start: startingPoint)
             bubble.layer.cornerRadius = bubble.frame.size.height / 2
             bubble.center = startingPoint
+            bubble.isHidden = false
 
             UIView.animate(withDuration: duration, animations: {
                 self.bubble.transform = CGAffineTransform(scaleX: 0.001, y: 0.001)


### PR DESCRIPTION
Fixed: bubble is displayed in other custom transition animation.

e.g. 
```swift
let transition = CATransition()
transition.duration = 0.3
transition.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
transition.type = kCATransitionPush
transition.subtype = kCATransitionFromLeft
view.window?.layer.add(transition, forKey: nil)
dismiss(animated: false, completion: nil)
```