### PR TITLE
no need to call appearance methods in fullscreen style.

### DIFF
--- a/Source/BubbleTransition.swift
+++ b/Source/BubbleTransition.swift
@@ -100,10 +100,12 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
         let fromViewController = transitionContext.viewController(forKey: .from)
         let toViewController = transitionContext.viewController(forKey: .to)
 
-        fromViewController?.beginAppearanceTransition(false, animated: true)
-        toViewController?.beginAppearanceTransition(true, animated: true)
-
         if transitionMode == .present {
+            fromViewController?.beginAppearanceTransition(false, animated: true)
+            if toViewController?.modalPresentationStyle == .custom {
+                toViewController?.beginAppearanceTransition(true, animated: true)
+            }
+            
             let presentedControllerView = transitionContext.view(forKey: UITransitionContextViewKey.to)!
             let originalCenter = presentedControllerView.center
             let originalSize = presentedControllerView.frame.size
@@ -130,9 +132,16 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
                     transitionContext.completeTransition(true)
                     self.bubble.isHidden = true
                     fromViewController?.endAppearanceTransition()
-                    toViewController?.endAppearanceTransition()
+                    if toViewController?.modalPresentationStyle == .custom {
+                        toViewController?.endAppearanceTransition()
+                    }
             })
         } else {
+            if fromViewController?.modalPresentationStyle == .custom {
+                fromViewController?.beginAppearanceTransition(false, animated: true)
+            }
+            toViewController?.beginAppearanceTransition(true, animated: true)
+            
             let key = (transitionMode == .pop) ? UITransitionContextViewKey.to : UITransitionContextViewKey.from
             let returningControllerView = transitionContext.view(forKey: key)!
             let originalCenter = returningControllerView.center
@@ -159,7 +168,9 @@ extension BubbleTransition: UIViewControllerAnimatedTransitioning {
                     self.bubble.removeFromSuperview()
                     transitionContext.completeTransition(true)
                     
-                    fromViewController?.endAppearanceTransition()
+                    if fromViewController?.modalPresentationStyle == .custom {
+                        fromViewController?.endAppearanceTransition()
+                    }
                     toViewController?.endAppearanceTransition()
             })
         }


### PR DESCRIPTION
I'm getting the following warning when I try to present a UINavigationController.

```
Unbalanced calls to begin/end appearance transitions for <UINavigationController>.
```

`UIModalPresentationFullScreen` already handle appearance method calls. no need to call `beginAppearanceTransition` and `endAppearanceTransition`

#### Reference
https://github.com/zoonooz/ZFDragableModalTransition/issues/49
https://github.com/zoonooz/ZFDragableModalTransition/commit/ced1811818d029d006f3fcdb9ce1199cbc39c9e9