### PR TITLE
Fix nil when there is not background color set

### DIFF
--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -30,14 +30,14 @@ class ViewController: UIViewController, UIViewControllerTransitioningDelegate {
   func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
     transition.transitionMode = .present
     transition.startingPoint = transitionButton.center
-    transition.bubbleColor = transitionButton.backgroundColor!
+    transition.bubbleColor = transitionButton.backgroundColor ?? .black
     return transition
   }
   
   func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
     transition.transitionMode = .dismiss
     transition.startingPoint = transitionButton.center
-    transition.bubbleColor = transitionButton.backgroundColor!
+    transition.bubbleColor = transitionButton.backgroundColor ?? .black
     return transition
   }
   

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ public override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
   transition.transitionMode = .present
   transition.startingPoint = someButton.center
-  transition.bubbleColor = someButton.backgroundColor!
+  transition.bubbleColor = someButton.backgroundColor ?? .black
   return transition
 }
 
 public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
   transition.transitionMode = .dismiss
   transition.startingPoint = someButton.center
-  transition.bubbleColor = someButton.backgroundColor!
+  transition.bubbleColor = someButton.backgroundColor ?? .black
   return transition
 }
 ```


### PR DESCRIPTION
If there is not background color set e.g in default created buttons, a nil stops execution when the optional is unwrapped.